### PR TITLE
Add API retry mechanism with delay

### DIFF
--- a/app/config/config/config.yaml
+++ b/app/config/config/config.yaml
@@ -3,3 +3,4 @@ api_url: https://api.5gla.de/api/v1
 api_version_endpoint: /info/version
 api_image_endpoint: /mica-sense/images/
 max_retries: 3
+retry_delay_seconds: 5

--- a/app/integration/api_integration_service.py
+++ b/app/integration/api_integration_service.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import requests
 
@@ -41,6 +42,10 @@ class ApiIntegrationService:
         for i in range(max_retries):
             if self._send_image(transaction_id, drone_id, channel, images):
                 return True
+            else:
+                logging.info(f"Retrying to send image. Attempt {i + 1}/{max_retries}")
+                logging.info(f"Sleeping for {ConfigManager().get('retry_interval')} seconds.")
+                time.sleep(ConfigManager().get('retry_interval'))
 
     def _send_image(self, transaction_id, drone_id, channel, images):
         """


### PR DESCRIPTION
In this commit, a retry mechanism with delay has been added for situations when sending an image to the API fails. A 'retry_delay_seconds' variable has been introduced in the config file, which specifies the delay between retries. In 'api_integration_service.py', code has been added to implement this delay using 'time.sleep()'. This enhancement offers improved robustness in handling intermittent API connectivity issues.

Closes #5 