### PR TITLE
Update CI workflow with max-parallel configuration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,6 +13,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         python-version: [ "3.10", "3.11" ]
 


### PR DESCRIPTION
Max-parallel option under the strategy scope has been added to the .github/workflows/continuous-integration.yml file. The configuration change ensures that the jobs across the build matrix run sequentially rather than in parallel. This is done to prevent race conditions and conserve resources when running tests during continuous integration.

Closes #10 