### PR TITLE
Fix relative path in image reading method

### DIFF
--- a/test/integration/test_5gla_image_sequence_sending.py
+++ b/test/integration/test_5gla_image_sequence_sending.py
@@ -33,5 +33,5 @@ class ImageSequenceSendingTest(unittest.TestCase):
 
     @staticmethod
     def _read_base64_encoded_image(image_name):
-        with open(f'./data/encoded_image_set/{image_name}', 'r') as file:
+        with open(f'data/encoded_image_set/{image_name}', 'r') as file:
             return file.read()


### PR DESCRIPTION
The relative path in the "_read_base64_encoded_image" method within "test_5gla_image_sequence_sending.py" was modified. The './data/' was replaced by 'data/', resolving a potential failure in locating the encoded_image_set directory during tests execution. This ensures the correct reading of base64 encoded images across different environments.