### PR TITLE
Add group_id to config and API data

### DIFF
--- a/src/config/config/config.yaml
+++ b/src/config/config/config.yaml
@@ -15,3 +15,4 @@ sending_interval_in_seconds: 3
 drone_id: a58de346188f1236 # Maximum 16 characters
 log_level: INFO
 log_level.console: INFO
+group_id: some_group_id_used_by_the_camera

--- a/src/integration/api_integration_service.py
+++ b/src/integration/api_integration_service.py
@@ -107,7 +107,8 @@ class ApiIntegrationService:
                    'Authorization': self._get_authorization_token()}
         data = {
             'latitude': latitude,
-            'longitude': longitude
+            'longitude': longitude,
+            'group': config_manager.get('group_id'),
         }
         max_retries = ConfigManager().get('max_retries')
         for i in range(max_retries):


### PR DESCRIPTION
A new parameter 'group_id' has been added to the configuration file and included in the data sent by the API integration service. This is expected to be used by the camera to group different data sets.