### PR TITLE
Rename 'micaSenseChannel' to 'imageChannel'

### DIFF
--- a/src/integration/api_integration_service.py
+++ b/src/integration/api_integration_service.py
@@ -86,7 +86,7 @@ class ApiIntegrationService:
         processed_images = []
         for image in images:
             processed_images.append({
-                'micaSenseChannel': channel,
+                'imageChannel': channel,
                 'base64Image': image
             })
         return processed_images


### PR DESCRIPTION
Updated the key name in processed_images dictionary from 'micaSenseChannel' to 'imageChannel' to maintain consistency and clarity in the codebase. This change ensures that the dictionary keys more accurately describe their content.