### PR TITLE
Fix incorrect key in API request payload

### DIFF
--- a/src/integration/api_integration_service.py
+++ b/src/integration/api_integration_service.py
@@ -49,7 +49,7 @@ class ApiIntegrationService:
                    'Authorization': self._get_authorization_token()}
         data = {
             'transactionId': transaction_id,
-            'droneId': camera_id,
+            'cameraId': camera_id,
             'images': self._process_images(channel, images)
         }
         max_retries = ConfigManager().get('max_retries')


### PR DESCRIPTION
The key 'droneId' was mistakenly used instead of 'cameraId' in the data payload for the API request. This change corrects that error, ensuring that the payload now correctly uses 'cameraId' to refer to the camera identifier.