### PR TITLE
Fix sleep interval type casting in app.py

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -43,4 +43,4 @@ else:
         else:
             logging.info("Position sending is disabled, skipping the process")
 
-        time.sleep(config_manager.get_env('SENDING_INTERVAL_IN_SECONDS'))
+        time.sleep(int(config_manager.get_env('SENDING_INTERVAL_IN_SECONDS')))


### PR DESCRIPTION
Convert SENDING_INTERVAL_IN_SECONDS to int before passing to time.sleep. This ensures proper functionality and avoids potential type errors during execution.